### PR TITLE
feat: observe key values changes

### DIFF
--- a/lib/src/registry_key.dart
+++ b/lib/src/registry_key.dart
@@ -202,26 +202,19 @@ class RegistryKey {
 
   void _waitForEvent(bool includeSubkeys) {
     try {
-      final eventHandle = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-
-      if (eventHandle == NULL) {
-        throw Exception('Unable to create event');
-      }
-
       final registerResult = RegNotifyChangeKeyValue(
         hkey,
         includeSubkeys ? TRUE : FALSE,
-        1 | 4,
-        eventHandle,
+        // REG_NOTIFY_CHANGE_NAME, REG_NOTIFY_CHANGE_ATTRIBUTES,
+        // REG_NOTIFY_CHANGE_LAST_SET
+        1 | 2 | 4,
+        NULL,
         FALSE,
       );
 
       if (registerResult != ERROR_SUCCESS) {
-        CloseHandle(eventHandle);
         throw WindowsException(HRESULT_FROM_WIN32(registerResult));
       }
-
-      CloseHandle(eventHandle);
     } catch (e) {
       rethrow;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: win32_registry
 description: A set of helper classes for working with the Windows registry.
-version: 1.1.0
+version: 1.2.0
 repository: https://github.com/timsneath/win32_registry
 issue_tracker: https://github.com/timsneath/win32_registry/issues
 
@@ -10,9 +10,11 @@ environment:
 platforms:
   windows:
 
-dependencies: 
+dependencies:
   ffi: ^2.0.0
-  win32: ^4.0.0
+  rxdart: ^0.27.0
+  win32: ^4.1.1
+  compute: 1.0.2
 
 dev_dependencies:
   lints: ^2.0.1


### PR DESCRIPTION
I've added the ability to observe changes of key values. User gets notification event via stream if values inside the key changes. Optionally, user can set `includeSubkeys` to also get notified about changes in subkeys.  We need to encapsulate `RegNotifyChangeKeyValue` function in isolate otherwise apps would be locked.