### PR TITLE
Fix issue with RegistryValue.data returned for REG_BINARY

### DIFF
--- a/lib/src/registry_value.dart
+++ b/lib/src/registry_value.dart
@@ -50,7 +50,9 @@ class RegistryValue {
         REG_VALUE_TYPE.REG_QWORD => RegistryValue(
             name, RegistryValueType.int64, byteData.cast<QWORD>().value),
         REG_VALUE_TYPE.REG_BINARY => RegistryValue(
-            name, RegistryValueType.binary, byteData.asTypedList(dataLength)),
+            name,
+            RegistryValueType.binary,
+            Uint8List.fromList(byteData.asTypedList(dataLength))),
         REG_VALUE_TYPE.REG_NONE =>
           RegistryValue(name, RegistryValueType.none, 0),
         _ => RegistryValue(name, RegistryValueType.unknown, 0)


### PR DESCRIPTION
Currently, the `RegistryValue.data` object returned for `REG_BINARY`-typed values is backed by a list which is a view of the provided `byteData` created by calling `asTypedList`. The [documentation for `asTypedList`](https://api.dart.dev/stable/2.15.1/dart-ffi/Int8Pointer/asTypedList.html) states: "The user has to ensure the memory range is accessible while using the returned list."

However, the memory for `byteData` may be freed before the caller is done with the returned `RegistryValue`, meaning the caller may get different/incorrect data each time they access the `RegistryValue.data` object.

Fix this issue by returning a copy of the `byteData`-backed list that is created before the memory for `byteData` is freed.