### PR TITLE
fix: Export access_rights so Registry.openPath can be called with desiredAccessRights

### DIFF
--- a/lib/win32_registry.dart
+++ b/lib/win32_registry.dart
@@ -9,6 +9,7 @@
 /// components.
 library;
 
+export 'src/access_rights.dart';
 export 'src/registry.dart';
 export 'src/registry_hive.dart';
 export 'src/registry_key.dart';


### PR DESCRIPTION
## Description

This change is needed so that Registry.openPath can be called with desiredAccessRights specified by the caller.

## Related Issue

n/a

## Type of Change

- [ ] 🚀 `feat` – New feature (non-breaking change that adds functionality)
- [x] 🛠️ `fix` – Bug fix (non-breaking change that fixes an issue)
- [ ] ❌ `!` – Breaking change (fix or feature that causes existing functionality to change)
- [ ] ⚡ `perf` – Performance improvement
- [ ] 🧹 `refactor` – Code refactor (no functionality change)
- [ ] 📝 `docs` – Documentation update
- [ ] 🎨 `style` – Code style changes (formatting, renaming, etc.)
- [ ] 🧪 `test` – Test update or addition
- [ ] 🔧 `build` – Build related changes
- [ ] ✅ `ci` – CI related changes
- [ ] 🗑️ `chore` – Chore (maintenance, non-production code change)
- [ ] ◀️  `revert` – Revert a previous commit
